### PR TITLE
Workspace icons

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1,5 +1,7 @@
+import QtQml
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import Quickshell
 import Quickshell.Hyprland
 import Quickshell.Io
@@ -17,6 +19,12 @@ import qs.Ui
 // system can read the current name with a cat, and writing one from a script
 // is a redirect. Both files are watched, so the bar picks that up without
 // being told.
+//
+// It can draw the workspace indicators as well, off by default. An icon is
+// only half useful on the workspace you are already on; the row of numbers is
+// where you look to find the one you want. Turned on, this widget replaces
+// omarchy.workspaces rather than sitting next to it, which is what keeps the
+// two from ever showing different icons for the same workspace.
 Panel {
   id: root
 
@@ -30,11 +38,24 @@ Panel {
   readonly property bool vertical: bar ? bar.vertical : false
   readonly property int barSize: bar ? bar.barSize : Style.bar.sizeHorizontal
 
+  // Drawing the indicators means standing in for omarchy.workspaces, which is
+  // too big a thing to switch on for someone who installed a name widget. Off
+  // until asked for.
+  readonly property bool showIndicators: setting("indicators", false) === true
+  // An icon in place of the number keeps a button one character wide, the size
+  // the stock indicators are built at. Keeping both reads as "icon 4" and has
+  // to grow the button, which is a change to the shape of the bar.
+  readonly property bool showNumbers: setting("numbers", false) === true
+
   readonly property string home: Quickshell.env("HOME") || ""
   readonly property string stateDir: (Quickshell.env("XDG_STATE_HOME") || home + "/.local/state") + "/workspace-hud"
 
   property string workspaceName: ""
   property string workspaceIcon: ""
+
+  // The icon the panel will save. Held here rather than in a field, because
+  // the picker is the whole of the icon interface now.
+  property string pickedIcon: ""
   readonly property int workspaceId: Hyprland.focusedWorkspace ? Hyprland.focusedWorkspace.id : 0
   readonly property bool hasName: workspaceName !== ""
   readonly property bool hasIcon: workspaceIcon !== ""
@@ -42,7 +63,12 @@ Panel {
   // An icon alone is a perfectly good label — a workspace can be the one with
   // the terminals without also being called "terminals" — so either half is
   // enough to put the widget on the bar.
+  //
+  // Except when the indicators are drawn: the icon is already sitting on this
+  // workspace's own button a few pixels to the left, and the same thing shown
+  // twice in one bar reads as two things. There the label is the name alone.
   readonly property string labelText: {
+    if (showIndicators) return workspaceName
     if (hasIcon && hasName) return workspaceIcon + "  " + workspaceName
     return hasIcon ? workspaceIcon : workspaceName
   }
@@ -50,16 +76,16 @@ Panel {
 
   // Brief accent flash whenever the label changes, so a workspace switch is
   // noticeable out of the corner of your eye instead of something you have to
-  // read. Skipped on the very first read, which would otherwise flash at
-  // login for no reason.
+  // read. Held back until both files have reported once: they are read
+  // independently, so whichever of the two lands second would otherwise
+  // flash at login for a label that was already right.
   property bool flashing: false
-  property bool seenFirstRead: false
+  property bool seenNameRead: false
+  property bool seenIconRead: false
+  readonly property bool seenFirstRead: seenNameRead && seenIconRead
 
   onLabelTextChanged: {
-    if (!seenFirstRead) {
-      seenFirstRead = true
-      return
-    }
+    if (!seenFirstRead) return
     flashing = true
     flashTimer.restart()
   }
@@ -70,28 +96,110 @@ Panel {
     onTriggered: root.flashing = false
   }
 
-  // Nothing to show without a name or an icon, so the widget takes no room.
-  implicitWidth: hasLabel ? label.implicitWidth + Style.space(16) : 0
-  implicitHeight: bar ? bar.barSize : Style.bar.sizeHorizontal
-
+  // Nothing to show without a name, an icon or a row of indicators, so the
+  // widget takes no room at all. The layout skips a hidden child, and
+  // WidgetButton hides itself on empty text, so this falls out on its own.
+  implicitWidth: content.implicitWidth
+  implicitHeight: content.implicitHeight
 
   // A small, opinionated set of icons for the things people actually keep a
-  // workspace for, so the common case is a click rather than a trip to the
-  // Nerd Fonts cheat sheet. Anything outside it still goes in the field by
-  // hand — the grid is a shortcut, not the vocabulary.
+  // workspace for. Brand marks are left out: a workspace is a kind of work,
+  // not a logo, and a picker full of them dates fast. The exceptions are the
+  // handful this bar's workspace indicators already use, so the two agree.
+  // Anything outside the set still goes in the file by hand, since that is
+  // the vocabulary and this is only the shortcut.
   //
   // Stored as codepoints rather than glyphs: Private Use Area characters do
   // not survive every editor and every copy-paste, and a list of them reads
   // as a column of blanks in a diff. Every one of these was checked against
   // the font Omarchy ships.
   readonly property var presetIcons: [
-    0xF120, 0xF121, 0xE73C, 0xE74E, 0xE7BA, 0xF1D3, 0xF09B, 0xF296,
-    0xF268, 0xF269, 0xF086, 0xF198, 0xF066F, 0xF099, 0xF0E0, 0xF292,
-    0xF001, 0xF1BC, 0xF03D, 0xF11B, 0xF1B6, 0xF030, 0xF03E, 0xF1FC,
-    0xF07B, 0xF02D, 0xF040, 0xF073, 0xF017, 0xF002, 0xF188, 0xF080,
-    0xF1C0, 0xF233, 0xF0C2, 0xE7B0, 0xF17C, 0xF179, 0xF17A, 0xF17B,
-    0xF015, 0xF013, 0xF023, 0xF0C3, 0xF135, 0xF0F4, 0xF005, 0xF04B
+    0xEAC4, 0xF120, 0xE73E, 0xF040, 0xF02D, 0xF07B, 0xE69C,
+    0xE8A4, 0xF01EE, 0xE217, 0xF232, 0xE820, 0xEB72, 0xF086, 0xF292,
+    0xEC1B, 0xF03D, 0xF030, 0xF03E, 0xF1FC, 0xF11B, 0xF108, 0xF073,
+    0xF017, 0xF002, 0xF188, 0xF080, 0xF1C0, 0xF233, 0xF0C2, 0xE712,
+    0xF015, 0xF013, 0xF023, 0xF0C3, 0xF135, 0xF0F4, 0xF005, 0xEA71
   ]
+  // Foreground at a given alpha, for the picker's hover and selection fills.
+  function tint(alpha) {
+    return Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, alpha)
+  }
+
+  // Which workspaces the row shows: one through five always, so the bar does
+  // not reflow as they come and go, plus whatever else exists up to ten. Same
+  // rule the stock indicators use, on purpose.
+  function workspaceIds() {
+    var ids = [1, 2, 3, 4, 5]
+    var values = Hyprland.workspaces.values
+
+    for (var i = 0; i < values.length; i++) {
+      var id = values[i].id
+      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
+    }
+
+    ids.sort(function(left, right) { return left - right })
+    return ids
+  }
+
+  readonly property var indicatorIds: showIndicators ? workspaceIds() : []
+
+  function workspaceById(id) {
+    var values = Hyprland.workspaces.values
+    for (var i = 0; i < values.length; i++) {
+      if (values[i].id === id) return values[i]
+    }
+
+    return null
+  }
+
+  function focusWorkspace(id) {
+    if (!root.bar) return
+    root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
+  }
+
+  // Icons for the whole row. Kept apart from the focused workspace's own
+  // reader below, which has to work for any id, including one past the ten
+  // the row draws.
+  property var indicatorIcons: ({})
+
+  // Replaced wholesale rather than edited in place: QML only notices a var
+  // property when it is assigned, so mutating the object would leave every
+  // button bound to it stale.
+  function setIndicatorIcon(id, glyph) {
+    var next = {}
+    for (var key in indicatorIcons) next[key] = indicatorIcons[key]
+
+    if (glyph === "") delete next[id]
+    else next[id] = glyph
+
+    indicatorIcons = next
+  }
+
+  // A workspace with no icon falls back to its number, which is the whole of
+  // what the stock indicators ever show. Ten reads as 0 there, so it does
+  // here.
+  function indicatorText(id) {
+    var icon = indicatorIcons[id] || ""
+    var number = id === 10 ? "0" : String(id)
+
+    if (icon === "") return number
+    return root.showNumbers ? icon + " " + number : icon
+  }
+
+  Instantiator {
+    model: root.indicatorIds
+
+    delegate: FileView {
+      required property var modelData
+
+      path: root.iconFilePath(modelData)
+      watchChanges: true
+      printErrors: false
+      onFileChanged: reload()
+      onLoaded: root.setIndicatorIcon(modelData, root.parseIcon(text().trim()))
+      onLoadFailed: root.setIndicatorIcon(modelData, "")
+    }
+  }
 
   function nameFilePath(id) {
     return root.stateDir + "/" + id
@@ -131,7 +239,7 @@ Panel {
       'if [ -n "$4" ]; then printf "%s\\n" "$4" > "$3"; else rm -f -- "$3"; fi',
       "sh",
       root.nameFilePath(root.workspaceId), nameField.text.trim(),
-      root.iconFilePath(root.workspaceId), root.parseIcon(iconField.text)]
+      root.iconFilePath(root.workspaceId), root.pickedIcon]
     writeProc.running = true
     close()
   }
@@ -153,8 +261,8 @@ Panel {
     // text() is stale inside the change signal, so go around through reload()
     // and read it in onLoaded.
     onFileChanged: reload()
-    onLoaded: root.workspaceName = text().trim()
-    onLoadFailed: root.workspaceName = ""
+    onLoaded: { root.workspaceName = text().trim(); root.seenNameRead = true }
+    onLoadFailed: { root.workspaceName = ""; root.seenNameRead = true }
   }
 
   // The icon file, on exactly the same terms as the name file. Parsed on read
@@ -166,8 +274,8 @@ Panel {
     watchChanges: true
     printErrors: false
     onFileChanged: reload()
-    onLoaded: root.workspaceIcon = root.parseIcon(text().trim())
-    onLoadFailed: root.workspaceIcon = ""
+    onLoaded: { root.workspaceIcon = root.parseIcon(text().trim()); root.seenIconRead = true }
+    onLoadFailed: { root.workspaceIcon = ""; root.seenIconRead = true }
   }
 
   // FileView only watches a file it can resolve, and it cannot create the
@@ -180,31 +288,100 @@ Panel {
 
   onOpenedChanged: {
     if (opened) {
-      iconField.text = workspaceIcon
       nameField.text = workspaceName
       nameField.selectAll()
+      pickedIcon = workspaceIcon
+      presets.currentIndex = -1
     }
   }
 
-  WidgetButton {
-    id: label
+  GridLayout {
+    id: content
     anchors.fill: parent
-    bar: root.bar
-    visible: root.hasLabel
-    text: root.labelText
-    active: root.flashing
-    horizontalMargin: 8
-    verticalPadding: 6
-    fixedWidth: root.vertical ? root.barSize : -1
-    fixedHeight: root.barSize
-    tooltipText: ""
-    onPressed: function(b) { root.toggle() }
+    columns: root.vertical ? 1 : root.indicatorIds.length + 1
+    columnSpacing: root.vertical ? 0 : Style.space(1)
+    rowSpacing: root.vertical ? Style.space(2) : 0
+
+    Repeater {
+      model: root.indicatorIds
+
+      Item {
+        required property int modelData
+
+        readonly property var workspace: root.workspaceById(modelData)
+        readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
+        readonly property bool focused: root.workspaceId === modelData
+
+        implicitWidth: button.implicitWidth
+        implicitHeight: button.implicitHeight
+
+        // The workspace you are on is marked by a filled block behind it, the
+        // way the stock indicators mark theirs, rather than by recoloring the
+        // glyph. An icon is picked to be recognised, and recoloring spends the
+        // one thing it was chosen for. The block sits under the icon, so both
+        // survive.
+        Rectangle {
+          anchors.fill: parent
+          anchors.topMargin: Style.space(3)
+          anchors.bottomMargin: Style.space(3)
+          radius: Style.cornerRadius
+          color: root.tint(0.18)
+          visible: parent.focused
+        }
+
+        WidgetButton {
+          id: button
+          anchors.fill: parent
+          bar: root.bar
+          text: root.indicatorText(parent.modelData)
+          opacity: parent.occupied || parent.focused ? 1 : 0.5
+          horizontalMargin: 6
+          verticalPadding: 6
+          fixedWidth: root.vertical ? root.barSize : (root.showNumbers ? -1 : Style.space(20))
+          fixedHeight: root.barSize
+          onPressed: function(b) { root.focusWorkspace(parent.modelData) }
+        }
+      }
+    }
+
+    WidgetButton {
+      id: label
+      bar: root.bar
+      text: root.labelText
+      active: root.flashing
+      // Wider than a plain button: the name is prose sitting in a row of
+      // single glyphs and needs the air to read as its own thing.
+      horizontalMargin: 16
+      verticalPadding: 6
+      fixedWidth: root.vertical ? root.barSize : -1
+      fixedHeight: root.barSize
+      tooltipText: ""
+      onPressed: function(b) { root.toggle() }
+    }
+  }
+
+  // The bar draws a dash under whichever module owns the open panel, centered
+  // on that module's slot. Centered on this one it lands mid-row, under a
+  // workspace that has nothing to do with the panel, and only its length is
+  // ours to set, never its place. A mark pointing at the wrong thing is worse
+  // than no mark, so the panel registers with the bar's one-popup-at-a-time
+  // coordinator under this stand-in instead of under the widget. The bar
+  // compares that registration against the module to decide what to mark, so
+  // it finds no match and marks nothing, while every other panel on the bar
+  // still closes this one when it opens.
+  QtObject {
+    id: popoutKey
+
+    readonly property bool popoutSwitchClosing: root.popoutSwitchClosing
+
+    function close() { root.close() }
+    function closeForPopoutSwitch() { root.closeForPopoutSwitch() }
   }
 
   KeyboardPanel {
     id: panel
-    anchorItem: label
-    owner: root
+    anchorItem: label.visible ? label : content
+    owner: popoutKey
     bar: root.bar
     open: root.opened
     focusTarget: nameField
@@ -223,75 +400,6 @@ Panel {
         fontFamily: root.fontFamily
       }
 
-      // The icon row previews what was typed next to the field, because a
-      // codepoint is unreadable and a pasted glyph is easy to get wrong —
-      // neither tells you what you are about to save until you see it drawn.
-      Row {
-        width: parent.width
-        spacing: Style.space(8)
-
-        TextField {
-          id: iconField
-          anchors.verticalCenter: parent.verticalCenter
-          width: parent.width - Style.space(28) - Style.space(8)
-          placeholderText: "Icon, or pick one below"
-          foreground: root.foreground
-          verticalPadding: Style.space(4)
-          onAccepted: root.save()
-          Keys.onEscapePressed: root.close()
-        }
-
-        Text {
-          anchors.verticalCenter: parent.verticalCenter
-          width: Style.space(28)
-          text: root.parseIcon(iconField.text)
-          color: root.foreground
-          font.family: root.fontFamily
-          font.pixelSize: Style.font.icon
-          horizontalAlignment: Text.AlignHCenter
-        }
-      }
-
-
-      // The picker sets the field rather than saving on the spot: the panel
-      // saves both halves together on Enter, and a click that wrote one of
-      // them straight to disk would make that rule a lie.
-      Grid {
-        id: presets
-        width: parent.width
-        columns: 8
-        spacing: Style.space(2)
-
-        readonly property real cell: Math.floor((width - spacing * (columns - 1)) / columns)
-
-        Repeater {
-          model: root.presetIcons
-
-          Rectangle {
-            required property var modelData
-            readonly property string glyph: String.fromCodePoint(modelData)
-
-            width: presets.cell
-            height: presets.cell
-            radius: Style.cornerRadius
-            color: iconField.text === glyph
-              ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
-              : (hover.hovered ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08) : "transparent")
-
-            Text {
-              anchors.centerIn: parent
-              text: parent.glyph
-              color: root.foreground
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.icon
-            }
-
-            HoverHandler { id: hover }
-            TapHandler { onTapped: iconField.text = parent.glyph }
-          }
-        }
-      }
-
       TextField {
         id: nameField
         width: parent.width
@@ -300,6 +408,99 @@ Panel {
         verticalPadding: Style.space(4)
         onAccepted: root.save()
         Keys.onEscapePressed: root.close()
+        Keys.onDownPressed: presets.forceActiveFocus()
+      }
+
+      // The picker sets what will be saved rather than saving on the spot:
+      // the panel saves both halves together on Enter, and a click that wrote
+      // an icon straight to disk would make that rule a lie.
+      //
+      // Arrow keys walk it once it has focus. Down out of the name field
+      // steps in, every move takes the icon under the cursor, and Up off the
+      // top row hands focus back. Enter saves from either place. The first
+      // cell is 'no icon', which is how a workspace gives one back.
+      Grid {
+        id: presets
+        width: parent.width
+        columns: 8
+        spacing: Style.space(2)
+        activeFocusOnTab: true
+
+        readonly property real cell: Math.floor((width - spacing * (columns - 1)) / columns)
+        // One cell more than there are icons: the first one clears.
+        readonly property int count: root.presetIcons.length + 1
+
+        // Where the keyboard cursor sits. -1 until the grid is entered, so a
+        // panel opened on a workspace with a hand-typed icon does not pretend
+        // one of the presets is selected.
+        property int currentIndex: -1
+
+        function glyphAt(i) {
+          return i === 0 ? "" : String.fromCodePoint(root.presetIcons[i - 1])
+        }
+
+        // Moving the cursor is the choice: there is no separate confirm
+        // step, so what you are pointing at is always what Enter will save.
+        function moveTo(i) {
+          if (i < 0 || i >= count) return
+          currentIndex = i
+          root.pickedIcon = glyphAt(i)
+        }
+
+        // Entering starts the cursor on the icon the workspace already has,
+        // so the eye does not have to find its way back to it.
+        onActiveFocusChanged: {
+          if (!activeFocus) return
+          if (currentIndex < 0) {
+            for (var i = 0; i < count; i++) {
+              if (glyphAt(i) === root.pickedIcon) { currentIndex = i; break }
+            }
+          }
+          moveTo(currentIndex < 0 ? 0 : currentIndex)
+        }
+
+        Keys.onLeftPressed: presets.moveTo(presets.currentIndex - 1)
+        Keys.onRightPressed: presets.moveTo(presets.currentIndex + 1)
+        Keys.onDownPressed: presets.moveTo(presets.currentIndex + presets.columns)
+        Keys.onUpPressed: {
+          if (presets.currentIndex < presets.columns) nameField.forceActiveFocus()
+          else presets.moveTo(presets.currentIndex - presets.columns)
+        }
+        Keys.onReturnPressed: root.save()
+        Keys.onEnterPressed: root.save()
+        Keys.onEscapePressed: root.close()
+
+        Repeater {
+          model: presets.count
+
+          Rectangle {
+            required property int index
+            readonly property string glyph: presets.glyphAt(index)
+            readonly property bool clears: index === 0
+            readonly property bool onCursor: presets.activeFocus && presets.currentIndex === index
+            readonly property bool chosen: root.pickedIcon === glyph
+
+            width: presets.cell
+            height: presets.cell
+            radius: Style.cornerRadius
+            color: onCursor ? root.tint(0.30)
+              : (chosen ? root.tint(0.18)
+              : (hover.hovered ? root.tint(0.08) : "transparent"))
+
+            Text {
+              anchors.centerIn: parent
+              // The clearing cell is drawn dim: it is the way out of the row,
+              // not one more thing in it.
+              text: parent.clears ? "\u00d7" : parent.glyph
+              color: parent.clears ? Qt.darker(root.foreground, 1.5) : root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.icon
+            }
+
+            HoverHandler { id: hover }
+            TapHandler { onTapped: presets.moveTo(parent.index) }
+          }
+        }
       }
     }
   }

--- a/Panel.qml
+++ b/Panel.qml
@@ -6,16 +6,17 @@ import Quickshell.Io
 import qs.Commons
 import qs.Ui
 
-// Workspace name: shows the name given to the current workspace, and lets you
-// set it.
+// Workspace name: shows the name and the icon given to the current workspace,
+// and lets you set them.
 //
-// The widget takes up no room at all until a workspace has a name, so a bar
-// with this in it looks untouched until you start using it.
+// The widget takes up no room at all until a workspace has one or the other,
+// so a bar with this in it looks untouched until you start using it.
 //
-// Names live one per file in $XDG_STATE_HOME/workspace-hud/<id>, plain text,
-// no daemon and no database. Anything else on the system can read the current
-// name with a cat, and writing one from a script is a redirect. The file is
-// watched, so the bar picks that up without being told.
+// Names and icons live one per file in $XDG_STATE_HOME/workspace-hud/<id> and
+// <id>.icon, plain text, no daemon and no database. Anything else on the
+// system can read the current name with a cat, and writing one from a script
+// is a redirect. Both files are watched, so the bar picks that up without
+// being told.
 Panel {
   id: root
 
@@ -33,17 +34,28 @@ Panel {
   readonly property string stateDir: (Quickshell.env("XDG_STATE_HOME") || home + "/.local/state") + "/workspace-hud"
 
   property string workspaceName: ""
+  property string workspaceIcon: ""
   readonly property int workspaceId: Hyprland.focusedWorkspace ? Hyprland.focusedWorkspace.id : 0
   readonly property bool hasName: workspaceName !== ""
+  readonly property bool hasIcon: workspaceIcon !== ""
 
-  // Brief accent flash whenever the name changes, so a workspace switch is
+  // An icon alone is a perfectly good label — a workspace can be the one with
+  // the terminals without also being called "terminals" — so either half is
+  // enough to put the widget on the bar.
+  readonly property string labelText: {
+    if (hasIcon && hasName) return workspaceIcon + "  " + workspaceName
+    return hasIcon ? workspaceIcon : workspaceName
+  }
+  readonly property bool hasLabel: labelText !== ""
+
+  // Brief accent flash whenever the label changes, so a workspace switch is
   // noticeable out of the corner of your eye instead of something you have to
   // read. Skipped on the very first read, which would otherwise flash at
   // login for no reason.
   property bool flashing: false
   property bool seenFirstRead: false
 
-  onWorkspaceNameChanged: {
+  onLabelTextChanged: {
     if (!seenFirstRead) {
       seenFirstRead = true
       return
@@ -58,21 +70,49 @@ Panel {
     onTriggered: root.flashing = false
   }
 
-  // Nothing to show without a name, so the widget takes no room at all.
-  implicitWidth: hasName ? label.implicitWidth + Style.space(16) : 0
+  // Nothing to show without a name or an icon, so the widget takes no room.
+  implicitWidth: hasLabel ? label.implicitWidth + Style.space(16) : 0
   implicitHeight: bar ? bar.barSize : Style.bar.sizeHorizontal
 
   function nameFilePath(id) {
     return root.stateDir + "/" + id
   }
 
+  function iconFilePath(id) {
+    return root.stateDir + "/" + id + ".icon"
+  }
+
+  // An icon can be given as the glyph itself or as its codepoint, because
+  // those are the two forms you are likely to have one in: a Nerd Font glyph
+  // can be pasted but not typed, and `echo f121 > 3.icon` is the kind of
+  // redirect the name file already invites.
+  //
+  // The first character is taken with codePointAt rather than by indexing:
+  // an icon outside the BMP (the Material Design set, U+F0000 and up) is a
+  // surrogate pair, and half of one draws as tofu.
+  function parseIcon(raw) {
+    var value = String(raw || "").trim()
+    if (value === "") return ""
+
+    var hex = value.match(/^(?:u\+|0x|\\u)?([0-9a-f]{4,6})$/i)
+    if (hex) {
+      var cp = parseInt(hex[1], 16)
+      if (cp > 0 && cp <= 0x10FFFF) return String.fromCodePoint(cp)
+    }
+
+    return String.fromCodePoint(value.codePointAt(0))
+  }
+
   function save() {
-    // The name is passed as an argument rather than spliced into the script,
+    // Each value is passed as an argument rather than spliced into the script,
     // so a name with a quote or a backtick in it stays a name.
     writeProc.command = ["sh", "-c",
       'mkdir -p -- "$(dirname -- "$1")"; ' +
-      'if [ -n "$2" ]; then printf "%s\\n" "$2" > "$1"; else rm -f -- "$1"; fi',
-      "sh", root.nameFilePath(root.workspaceId), nameField.text.trim()]
+      'if [ -n "$2" ]; then printf "%s\\n" "$2" > "$1"; else rm -f -- "$1"; fi; ' +
+      'if [ -n "$4" ]; then printf "%s\\n" "$4" > "$3"; else rm -f -- "$3"; fi',
+      "sh",
+      root.nameFilePath(root.workspaceId), nameField.text.trim(),
+      root.iconFilePath(root.workspaceId), root.parseIcon(iconField.text)]
     writeProc.running = true
     close()
   }
@@ -98,6 +138,19 @@ Panel {
     onLoadFailed: root.workspaceName = ""
   }
 
+  // The icon file, on exactly the same terms as the name file. Parsed on read
+  // as well as on write, so a codepoint dropped in from a script shows up as
+  // the glyph rather than as four literal characters.
+  FileView {
+    id: iconFileView
+    path: root.workspaceId > 0 ? root.iconFilePath(root.workspaceId) : ""
+    watchChanges: true
+    printErrors: false
+    onFileChanged: reload()
+    onLoaded: root.workspaceIcon = root.parseIcon(text().trim())
+    onLoadFailed: root.workspaceIcon = ""
+  }
+
   // FileView only watches a file it can resolve, and it cannot create the
   // directory the first name will be written into. Do that once at startup.
   Process {
@@ -108,6 +161,7 @@ Panel {
 
   onOpenedChanged: {
     if (opened) {
+      iconField.text = workspaceIcon
       nameField.text = workspaceName
       nameField.selectAll()
     }
@@ -117,8 +171,8 @@ Panel {
     id: label
     anchors.fill: parent
     bar: root.bar
-    visible: root.hasName
-    text: root.workspaceName
+    visible: root.hasLabel
+    text: root.labelText
     active: root.flashing
     horizontalMargin: 8
     verticalPadding: 6
@@ -148,6 +202,35 @@ Panel {
         text: "WORKSPACE " + root.workspaceId
         foreground: root.foreground
         fontFamily: root.fontFamily
+      }
+
+      // The icon row previews what was typed next to the field, because a
+      // codepoint is unreadable and a pasted glyph is easy to get wrong —
+      // neither tells you what you are about to save until you see it drawn.
+      Row {
+        width: parent.width
+        spacing: Style.space(8)
+
+        TextField {
+          id: iconField
+          anchors.verticalCenter: parent.verticalCenter
+          width: parent.width - Style.space(28) - Style.space(8)
+          placeholderText: "Icon: paste a glyph or type f121"
+          foreground: root.foreground
+          verticalPadding: Style.space(4)
+          onAccepted: root.save()
+          Keys.onEscapePressed: root.close()
+        }
+
+        Text {
+          anchors.verticalCenter: parent.verticalCenter
+          width: Style.space(28)
+          text: root.parseIcon(iconField.text)
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.icon
+          horizontalAlignment: Text.AlignHCenter
+        }
       }
 
       TextField {

--- a/Panel.qml
+++ b/Panel.qml
@@ -74,6 +74,25 @@ Panel {
   implicitWidth: hasLabel ? label.implicitWidth + Style.space(16) : 0
   implicitHeight: bar ? bar.barSize : Style.bar.sizeHorizontal
 
+
+  // A small, opinionated set of icons for the things people actually keep a
+  // workspace for, so the common case is a click rather than a trip to the
+  // Nerd Fonts cheat sheet. Anything outside it still goes in the field by
+  // hand — the grid is a shortcut, not the vocabulary.
+  //
+  // Stored as codepoints rather than glyphs: Private Use Area characters do
+  // not survive every editor and every copy-paste, and a list of them reads
+  // as a column of blanks in a diff. Every one of these was checked against
+  // the font Omarchy ships.
+  readonly property var presetIcons: [
+    0xF120, 0xF121, 0xE73C, 0xE74E, 0xE7BA, 0xF1D3, 0xF09B, 0xF296,
+    0xF268, 0xF269, 0xF086, 0xF198, 0xF066F, 0xF099, 0xF0E0, 0xF292,
+    0xF001, 0xF1BC, 0xF03D, 0xF11B, 0xF1B6, 0xF030, 0xF03E, 0xF1FC,
+    0xF07B, 0xF02D, 0xF040, 0xF073, 0xF017, 0xF002, 0xF188, 0xF080,
+    0xF1C0, 0xF233, 0xF0C2, 0xE7B0, 0xF17C, 0xF179, 0xF17A, 0xF17B,
+    0xF015, 0xF013, 0xF023, 0xF0C3, 0xF135, 0xF0F4, 0xF005, 0xF04B
+  ]
+
   function nameFilePath(id) {
     return root.stateDir + "/" + id
   }
@@ -215,7 +234,7 @@ Panel {
           id: iconField
           anchors.verticalCenter: parent.verticalCenter
           width: parent.width - Style.space(28) - Style.space(8)
-          placeholderText: "Icon: paste a glyph or type f121"
+          placeholderText: "Icon, or pick one below"
           foreground: root.foreground
           verticalPadding: Style.space(4)
           onAccepted: root.save()
@@ -230,6 +249,46 @@ Panel {
           font.family: root.fontFamily
           font.pixelSize: Style.font.icon
           horizontalAlignment: Text.AlignHCenter
+        }
+      }
+
+
+      // The picker sets the field rather than saving on the spot: the panel
+      // saves both halves together on Enter, and a click that wrote one of
+      // them straight to disk would make that rule a lie.
+      Grid {
+        id: presets
+        width: parent.width
+        columns: 8
+        spacing: Style.space(2)
+
+        readonly property real cell: Math.floor((width - spacing * (columns - 1)) / columns)
+
+        Repeater {
+          model: root.presetIcons
+
+          Rectangle {
+            required property var modelData
+            readonly property string glyph: String.fromCodePoint(modelData)
+
+            width: presets.cell
+            height: presets.cell
+            radius: Style.cornerRadius
+            color: iconField.text === glyph
+              ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+              : (hover.hovered ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08) : "transparent")
+
+            Text {
+              anchors.centerIn: parent
+              text: parent.glyph
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.icon
+            }
+
+            HoverHandler { id: hover }
+            TapHandler { onTapped: iconField.text = parent.glyph }
+          }
         }
       }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Workspace name
 
 An [Omarchy](https://omarchy.org) bar widget that gives the current workspace a
-name, and lets you type a new one.
+name and an icon, and lets you set both.
 
 ![The widget in the bar: switching workspaces, and renaming one](demo.gif)
 
@@ -10,8 +10,13 @@ what you were doing there. This widget puts a short label next to the workspace
 indicators: `invoicing`, `bug #4412`, `reading`. Switch workspaces and the label
 follows.
 
-Until a workspace has a name the widget takes up no room at all, so a bar with
-this in it looks untouched until you start using it.
+A workspace can also carry an icon, on its own or in front of the name. An icon
+alone is often enough — a workspace can be the one with the terminals without
+also being called "terminals" — and it reads faster in the corner of your eye
+than a word does.
+
+Until a workspace has a name or an icon the widget takes up no room at all, so
+a bar with this in it looks untouched until you start using it.
 
 ## Install
 
@@ -28,18 +33,25 @@ The widget lands in the left section of the bar by default. Move it with
 omarchy plugin remove jankeesvw.workspace-name
 ```
 
-That takes the widget out of the bar and deletes the plugin. The names you gave
-your workspaces are yours, not the plugin's, so they stay behind in
+That takes the widget out of the bar and deletes the plugin. The names and
+icons you gave your workspaces are yours, not the plugin's, so they stay in
 `$XDG_STATE_HOME/workspace-hud/`. Delete that directory if you want them gone
 too.
 
 ## Use
 
-Click the label to open the panel, type a name, press Enter. An empty name
-clears it and the widget disappears again. Escape closes without saving.
+Click the label to open the panel. It has two fields: an icon and a name. Fill
+in either, both, or neither — press Enter to save. Emptying a field clears that
+half, and clearing both makes the widget disappear again. Escape closes without
+saving.
 
-Since a workspace with no name shows nothing, there is nothing to click on the
-first one you want to label, so bind a key to open the panel:
+The icon field takes the two forms you are likely to have an icon in: **paste
+the glyph**, or type its **codepoint** (`f121`, `U+F121`, `0xF121`). Both are
+needed — a Nerd Font glyph cannot be typed and a codepoint cannot be read — so
+the preview beside the field shows what is about to be saved.
+
+Since a workspace with no name and no icon shows nothing, there is nothing to
+click on the first one you want to label, so bind a key to open the panel:
 
 ```lua
 -- ~/.config/hypr/bindings.lua
@@ -48,11 +60,11 @@ o.bind(hyper .. "R", "Workspace name", "omarchy-shell shell toggle jankeesvw.wor
 
 That is the way in, and it stays the faster way once names are everywhere.
 
-## Where names are stored
+## Where names and icons are stored
 
-One plain-text file per workspace, in `$XDG_STATE_HOME/workspace-hud/<id>`
-(usually `~/.local/state/workspace-hud/1`, `.../2`, and so on). No daemon, no
-database.
+One plain-text file per workspace, in `$XDG_STATE_HOME/workspace-hud/<id>`,
+and the icon beside it in `<id>.icon` (usually `~/.local/state/workspace-hud/1`
+and `1.icon`, and so on). No daemon, no database.
 
 That means other tooling can join in. Reading the name of workspace 3 is a
 `cat`:
@@ -66,6 +78,15 @@ change without being told:
 
 ```bash
 echo "deploying" > ~/.local/state/workspace-hud/3
+```
+
+Icons work the same way, and the file accepts a codepoint as readily as the
+glyph itself — which is what makes them scriptable at all, since a Private Use
+Area character is awkward to get into a shell command and impossible to read
+back in a diff:
+
+```bash
+echo f120 > ~/.local/state/workspace-hud/3.icon
 ```
 
 Which is handy for scripts: a build wrapper can label the workspace it is

--- a/README.md
+++ b/README.md
@@ -40,19 +40,23 @@ too.
 
 ## Use
 
-Click the label to open the panel. It has two fields: an icon and a name. Fill
-in either, both, or neither — press Enter to save. Emptying a field clears that
-half, and clearing both makes the widget disappear again. Escape closes without
-saving.
+Click the label to open the panel. It holds a name field and, under it, a grid
+of icons. Fill in either, both, or neither, then press Enter to save. An empty
+name clears the name, the first cell of the grid (`×`) clears the icon, and
+clearing both makes the widget disappear again. Escape closes without saving.
 
-Under the icon field is a grid of common ones — terminals, browsers, chat,
-music, databases, the usual suspects. Click one and it drops into the field.
+The panel opens on the name, because renaming is what you came for on most
+days. Press Down to step into the grid and walk it with the arrow keys. Every
+move takes the icon under the cursor, so what you are pointing at is always
+what Enter will save. The icon the workspace already has is where the cursor
+starts and stays highlighted, Up off the top row hands focus back to the name,
+and clicking a cell does the same as walking onto it.
 
-For anything outside the grid, the field takes the two forms you are likely to
-have an icon in: **paste the glyph**, or type its **codepoint** (`f121`,
-`U+F121`, `0xF121`). Both are needed — a Nerd Font glyph cannot be typed and a
-codepoint cannot be read — so the preview beside the field shows what is about
-to be saved.
+The grid holds what a workspace is usually for: shells and editors, mail and
+chat, media, infrastructure. Brand marks are mostly left out, since a
+workspace is a kind of work rather than a logo. For anything the grid does not
+have, write the file directly. That takes a codepoint as readily as the glyph,
+which is covered below.
 
 Since a workspace with no name and no icon shows nothing, there is nothing to
 click on the first one you want to label, so bind a key to open the panel:
@@ -63,6 +67,30 @@ o.bind(hyper .. "R", "Workspace name", "omarchy-shell shell toggle jankeesvw.wor
 ```
 
 That is the way in, and it stays the faster way once names are everywhere.
+
+## Drawing the indicators too
+
+The widget can draw the row of workspace buttons as well. It is off until you
+ask for it, in the widget's entry in `~/.config/omarchy/shell.json`:
+
+```json
+{ "id": "jankeesvw.workspace-name", "indicators": true }
+```
+
+Each button carries the workspace's icon where one is set and its number where
+none is, and clicking one focuses that workspace. It stands in for the
+`omarchy.workspaces` widget rather than sitting beside it, so take that one out
+of the bar first.
+
+An icon standing in for the number keeps a button one character wide, which is
+the width the stock indicators are built at, so nothing about the shape of the
+bar changes. Set `"numbers": true` to show both instead. That reads as `icon 4`
+and grows every button to fit.
+
+The reason to want this: an icon on the workspace you are already standing on
+is only half useful, since the row of numbers is where you look to find the one
+you want. Feeding the row and the label from the same file is what keeps them
+from ever disagreeing.
 
 ## Where names and icons are stored
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,14 @@ in either, both, or neither — press Enter to save. Emptying a field clears tha
 half, and clearing both makes the widget disappear again. Escape closes without
 saving.
 
-The icon field takes the two forms you are likely to have an icon in: **paste
-the glyph**, or type its **codepoint** (`f121`, `U+F121`, `0xF121`). Both are
-needed — a Nerd Font glyph cannot be typed and a codepoint cannot be read — so
-the preview beside the field shows what is about to be saved.
+Under the icon field is a grid of common ones — terminals, browsers, chat,
+music, databases, the usual suspects. Click one and it drops into the field.
+
+For anything outside the grid, the field takes the two forms you are likely to
+have an icon in: **paste the glyph**, or type its **codepoint** (`f121`,
+`U+F121`, `0xF121`). Both are needed — a Nerd Font glyph cannot be typed and a
+codepoint cannot be read — so the preview beside the field shows what is about
+to be saved.
 
 Since a workspace with no name and no icon shows nothing, there is nothing to
 click on the first one you want to label, so bind a key to open the panel:
@@ -94,6 +98,36 @@ running in, and clear the label when it finishes.
 
 Names are not remembered across reboots any longer than the state directory
 is; nothing prunes them, so a name stays on a workspace until you clear it.
+
+## Where the icons come from
+
+The font. There is nothing icon-specific in the widget: it draws a character,
+and if the bar's font has that character you get a picture instead of a box.
+
+That works because Omarchy's bar uses a **Nerd Font** — an ordinary monospace
+face patched to carry whole icon sets (Font Awesome, Material Design,
+Devicons, Octicons, Seti-UI) in Unicode's Private Use Area. An icon is
+literally a character, which is why `echo f120 > 3.icon` is enough to set one.
+
+**Recommended: whatever Nerd Font your bar already uses.** Omarchy ships
+[JetBrainsMono Nerd Font](https://www.nerdfonts.com/font-downloads) and the
+grid above was checked glyph by glyph against it, so the presets are safe out
+of the box. Any other Nerd Font works too; only the coverage changes.
+
+To go beyond the grid, search [the Nerd Fonts cheat
+sheet](https://www.nerdfonts.com/cheat-sheet) by name and take the codepoint.
+Check it before you rely on it, because the cheat sheet describes the whole
+Nerd Fonts collection and your build may be a subset:
+
+```bash
+fc-list ":charset=f121" family    # empty means your font does not have it
+```
+
+If it comes back empty, you are not stuck: the toolkit falls back to any other
+installed font that does have the codepoint. Installing a font that carries the
+icon is enough — nothing has to be configured. The one case fallback cannot fix
+is a codepoint your main font already uses for something else, since the main
+font wins; there you would have to change the bar's font rather than add one.
 
 ## Requirements
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "Workspace name",
   "version": "1.0.0",
   "author": "Jankees van Woezik",
-  "description": "Name and icon of the current workspace, with fields to set them",
+  "description": "Name and icon of the current workspace, and optionally the workspace indicators",
   "homepage": "https://github.com/jankeesvw/omarchy-workspace-name",
   "license": "MIT",
   "kinds": [
@@ -15,9 +15,29 @@
   },
   "barWidget": {
     "displayName": "Workspace name",
-    "description": "Name and icon of the current workspace, with fields to set them",
+    "description": "Name and icon of the current workspace, and optionally the workspace indicators",
     "category": "Compositor",
     "allowMultiple": false,
-    "defaultSection": "left"
+    "defaultSection": "left",
+    "defaults": {
+      "indicators": false,
+      "numbers": false
+    },
+    "schema": [
+      {
+        "key": "indicators",
+        "type": "boolean",
+        "label": "Draw the workspace indicators",
+        "defaultValue": false,
+        "description": "A button per workspace, showing its icon where one is set and its number where none is. This stands in for the Workspaces widget rather than sitting beside it, so take that one out of the bar first."
+      },
+      {
+        "key": "numbers",
+        "type": "boolean",
+        "label": "Keep the number beside the icon",
+        "defaultValue": false,
+        "description": "Show icon and number together instead of letting the icon stand in for the number. Each button grows past the single-character slot the stock indicators use."
+      }
+    ]
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "Workspace name",
   "version": "1.0.0",
   "author": "Jankees van Woezik",
-  "description": "Name of the current workspace, with a field to set it",
+  "description": "Name and icon of the current workspace, with fields to set them",
   "homepage": "https://github.com/jankeesvw/omarchy-workspace-name",
   "license": "MIT",
   "kinds": [
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Workspace name",
-    "description": "Name of the current workspace, with a field to set it",
+    "description": "Name and icon of the current workspace, with fields to set them",
     "category": "Compositor",
     "allowMultiple": false,
     "defaultSection": "left"


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.97.0
## Give a workspace an icon as well as a name

A workspace can now carry an icon beside its name, set from the same panel, and
the widget can draw the workspace indicators with those icons on them.

An icon is recognised in the corner of the eye where a word has to be read, and
it is often the whole label a workspace needs: the one with the terminals does
not also have to be called "terminals".

Opened by @viktorvillalobos, whose two commits are the icon itself and the
first picker. The third commit reshapes that picker and takes it out to the
indicators; what changed and why is at the bottom.

## How it fits what is already here

- The icon lives in `<id>.icon` next to `<id>`: same one file per workspace,
  plain text, watched, no daemon.
- It is parsed on read as well as on write, so `echo f120 > 3.icon` works as
  well as pasting the glyph. A Private Use Area character is awkward to get
  into a shell command and unreadable in a diff, so the codepoint form is what
  makes icons as scriptable as names already are.
- The zero-width rule becomes "no name **and** no icon", so the widget still
  takes up no room until you use it.

## The panel

Opens on the name, because renaming is what you came for on most days, with a
grid of icons under it. Fill in either, both or neither, Enter saves, Escape
closes without saving.

The grid is the whole of the icon interface. Its first cell (`×`) clears the
icon, drawn dim because it is the way out of the row rather than one more thing
in it, and a workspace with no icon opens with that cell lit. The icon a
workspace already has is highlighted, and the keyboard cursor starts on it.

Down steps into the grid and the arrow keys walk it. Every move takes the icon
under the cursor, so what you are pointing at is always what Enter will save.
Up off the top row hands focus back to the name. Clicking a cell does the same
as walking onto it.

Anything the grid does not carry goes in by writing the file, which takes a
codepoint as readily as the glyph.

## The icons

39 of them, five rows, no brand marks. A workspace is a kind of work rather
than a product: "the browser one" is not Chrome any more than it is Firefox,
and a wall of trademarks is the part of a picker that dates first. What is in
there instead are the glyphs a bar's own workspace indicators tend to use, so
the two cannot disagree about what a terminal or a checked box looks like.

Every codepoint was checked against the Nerd Font Omarchy ships, so none render
as a box.

## Drawing the indicators

Off until you ask for it, in the widget's entry in `shell.json`:

```json
{ "id": "jankeesvw.workspace-name", "indicators": true }
```

Each button carries the workspace's icon where one is set and its number where
none is, and clicking one focuses that workspace. It stands in for
`omarchy.workspaces` rather than sitting beside it, so take that one out of the
bar first: two widgets reading the same files are still two widgets that can be
configured into disagreeing, and one widget cannot disagree with itself.

An icon standing in for the number keeps a button one character wide, the width
the stock indicators are built at, so nothing about the shape of the bar
changes. `"numbers": true` shows both instead and grows each button to fit.

The workspace you are on gets a filled block behind its button rather than a
recolored glyph, since an icon is picked to be recognised and recoloring spends
the one thing it was chosen for. With the row drawn, the label is the name
alone, because the icon is already on that workspace's own button and the same
thing twice in one bar reads as two things.

## What changed from the first version, and why

- **The icon text field is gone.** It mostly wanted a codepoint, which is a
  fine escape hatch and a poor front door, and it sat in the panel looking like
  a search box that searched nothing. Clearing an icon moved to the grid's
  first cell.
- **The name went back on top.** The picker had pushed it below six rows of
  icons, and renaming is still the common case.
- **48 icons became 39.** The logos came out, and two envelopes, two music
  notes and two `</>` glyphs were in the list at once; each pair is one entry
  now.
- **Two fixes.** The change-flash fired at login whenever a workspace had both
  a name and an icon: the two files are read independently and whichever landed
  second changed the label a second time, past a guard that could only count to
  one. Each file raises its own flag now. And the picker compared its field
  verbatim, so typing a codepoint drew the icon in the preview while leaving
  its own tile dark; it compares the parsed icon now.
- **The bar's open-panel mark is declined.** That mark is centered on the
  module, and centered on a whole row of workspaces it points at one that has
  nothing to do with the panel. Only its length is exposed, never its place,
  and a mark pointing at the wrong thing is worse than no mark, so the panel
  registers with the bar's one-popup-at-a-time coordinator under a stand-in.
  Every other panel still closes this one when it opens.

## Screenshot

<img width="1304" height="668" alt="screenshot-2026-08-18_10-51-23" src="https://github.com/user-attachments/assets/6e3adb14-edc8-486b-91ec-b91796f5e9e7" />

