### PR TITLE
Default indicators on and middle-click to open naming panel

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -40,9 +40,9 @@ Panel {
   readonly property int barSize: bar ? bar.barSize : Style.bar.sizeHorizontal
 
   // Drawing the indicators means standing in for omarchy.workspaces, which is
-  // too big a thing to switch on for someone who installed a name widget. Off
-  // until asked for.
-  readonly property bool showIndicators: setting("indicators", false) === true
+  // too big a thing to switch on for someone who installed a name widget. On
+  // by default; set "indicators": false in shell.json to hide them.
+  readonly property bool showIndicators: setting("indicators", true) === true
   // An icon in place of the number keeps a button one character wide, the size
   // the stock indicators are built at. Keeping both reads as "icon 4" and has
   // to grow the button, which is a change to the shape of the bar.
@@ -77,7 +77,13 @@ Panel {
   readonly property string labelText: {
     if (showIndicators) return workspaceName
     if (hasIcon && hasName) return workspaceIcon + "  " + workspaceName
-    return hasIcon ? workspaceIcon : workspaceName
+    if (hasIcon) return workspaceIcon
+    if (workspaceName) return workspaceName
+    // Placeholder: show the workspace number so there is something to click
+    // on to open the naming panel.  Only after the initial file read, so the
+    // widget stays invisible during the brief load.
+    if (seenFirstRead && workspaceId > 0) return String(workspaceId)
+    return ""
   }
   readonly property bool hasLabel: labelText !== ""
 
@@ -103,9 +109,10 @@ Panel {
     onTriggered: root.flashing = false
   }
 
-  // Nothing to show without a name, an icon or a row of indicators, so the
-  // widget takes no room at all. The layout skips a hidden child, and
-  // WidgetButton hides itself on empty text, so this falls out on its own.
+  // Without a name, an icon or a row of indicators the widget shows only a
+  // workspace-number placeholder — big enough to click, small enough to stay
+  // out of the way.  The layout skips a hidden child, and WidgetButton hides
+  // itself on empty text, so both cases fall out on their own.
   implicitWidth: content.implicitWidth
   implicitHeight: content.implicitHeight
 
@@ -418,7 +425,10 @@ Panel {
           verticalPadding: 6
           fixedWidth: root.vertical ? root.barSize : (root.showNumbers ? -1 : Style.space(20))
           fixedHeight: root.barSize
-          onPressed: function(b) { root.focusWorkspace(parent.modelData) }
+          onPressed: function(b) {
+            if (b === Qt.RightButton || b === Qt.MiddleButton) root.open()
+            else root.focusWorkspace(parent.modelData)
+          }
         }
       }
     }
@@ -435,7 +445,10 @@ Panel {
       fixedWidth: root.vertical ? root.barSize : -1
       fixedHeight: root.barSize
       tooltipText: ""
-      onPressed: function(b) { root.toggle() }
+      onPressed: function(b) {
+        if (b === Qt.RightButton || b === Qt.MiddleButton) root.open()
+        else root.toggle()
+      }
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -445,10 +445,7 @@ Panel {
       fixedWidth: root.vertical ? root.barSize : -1
       fixedHeight: root.barSize
       tooltipText: ""
-      onPressed: function(b) {
-        if (b === Qt.RightButton || b === Qt.MiddleButton) root.open()
-        else root.toggle()
-      }
+      onPressed: function(b) { root.toggle() }
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -97,6 +97,11 @@ Panel {
   property bool seenIconRead: false
   readonly property bool seenFirstRead: seenNameRead && seenIconRead
 
+  // The panel names the workspace it was opened on. Move to another one and
+  // it is aimed at a workspace you have left, its fields filling with someone
+  // else's name under your hands, so it closes instead of following along.
+  onWorkspaceIdChanged: if (opened) close()
+
   onLabelTextChanged: {
     if (!seenFirstRead) return
     flashing = true
@@ -425,8 +430,12 @@ Panel {
           verticalPadding: 6
           fixedWidth: root.vertical ? root.barSize : (root.showNumbers ? -1 : Style.space(20))
           fixedHeight: root.barSize
+          // Clicking the workspace you are already on has nothing to focus,
+          // so that click opens the panel instead. The button you are looking
+          // at is the one you want to name, and it takes the same plain left
+          // click as everything else on the bar.
           onPressed: function(b) {
-            if (b === Qt.RightButton || b === Qt.MiddleButton) root.open()
+            if (parent.focused) root.toggle()
             else root.focusWorkspace(parent.modelData)
           }
         }

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ name and an icon, and lets you set both.
 ![The widget in the bar: switching workspaces, and renaming one](demo.gif)
 
 Hyprland workspaces are numbered, and a number tells you where you are but not
-what you were doing there. This widget puts a short label next to the workspace
-indicators: `invoicing`, `bug #4412`, `reading`. Switch workspaces and the label
-follows.
+what you were doing there. This widget shows a row of workspace buttons with
+the current workspace's name or icon beside them: `invoicing`, `bug #4412`,
+`reading`. Switch workspaces and the label follows.
 
 A workspace can also carry an icon, on its own or in front of the name. An icon
 alone is often enough — a workspace can be the one with the terminals without
 also being called "terminals" — and it reads faster in the corner of your eye
 than a word does.
 
-Until a workspace has a name or an icon the widget takes up no room at all, so
-a bar with this in it looks untouched until you start using it.
+The widget draws a row of workspace number buttons by default, with the current
+workspace's name or icon beside them. Middle-click (or two-finger click on a
+trackpad) any workspace button to open the naming panel.
 
 ## Install
 
@@ -40,10 +41,12 @@ too.
 
 ## Use
 
-Click the label to open the panel. It holds a name field and, under it, a grid
-of icons. Fill in either, both, or neither, then press Enter to save. An empty
-name clears the name, the first cell of the grid (`×`) clears the icon, and
-clearing both makes the widget disappear again. Escape closes without saving.
+Workspace numbers appear on the bar by default. Middle-click (or two-finger
+click on a trackpad) any workspace button to open the naming panel. It holds a
+name field and, under it, a grid of icons. Fill in either, both, or neither,
+then press Enter to save. An empty name clears the name, the first cell of the
+grid (`×`) clears the icon, and clearing both hides the label. Escape closes
+without saving.
 
 The panel opens on the name, because renaming is what you came for on most
 days. Press Down to step into the grid and walk it with the arrow keys. Every
@@ -58,24 +61,14 @@ workspace is a kind of work rather than a logo. For anything the grid does not
 have, write the file directly. That takes a codepoint as readily as the glyph,
 which is covered below.
 
-Since a workspace with no name and no icon shows nothing, there is nothing to
-click on the first one you want to label, so bind a key to open the panel:
+You can also bind a key to open the panel directly:
 
 ```lua
 -- ~/.config/hypr/bindings.lua
 o.bind(hyper .. "R", "Workspace name", "omarchy-shell shell toggle jankeesvw.workspace-name")
 ```
 
-That is the way in, and it stays the faster way once names are everywhere.
-
-## Drawing the indicators too
-
-The widget can draw the row of workspace buttons as well. It is off until you
-ask for it, in the widget's entry in `~/.config/omarchy/shell.json`:
-
-```json
-{ "id": "jankeesvw.workspace-name", "indicators": true }
-```
+## Workspace indicators
 
 Each button carries the workspace's icon where one is set and its number where
 none is, and clicking one focuses that workspace. It stands in for the
@@ -91,6 +84,13 @@ The reason to want this: an icon on the workspace you are already standing on
 is only half useful, since the row of numbers is where you look to find the one
 you want. Feeding the row and the label from the same file is what keeps them
 from ever disagreeing.
+
+The indicators are on by default. To hide them, set `"indicators": false` in
+the widget's entry in `~/.config/omarchy/shell.json`:
+
+```json
+{ "id": "jankeesvw.workspace-name", "indicators": false }
+```
 
 ## Where names and icons are stored
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ also being called "terminals" — and it reads faster in the corner of your eye
 than a word does.
 
 The widget draws a row of workspace number buttons by default, with the current
-workspace's name or icon beside them. Middle-click (or two-finger click on a
-trackpad) any workspace button to open the naming panel.
+workspace's name or icon beside them. Click the workspace you are already on to
+open the naming panel.
 
 ## Install
 
@@ -41,9 +41,10 @@ too.
 
 ## Use
 
-Workspace numbers appear on the bar by default. Middle-click (or two-finger
-click on a trackpad) any workspace button to open the naming panel. It holds a
-name field and, under it, a grid of icons. Fill in either, both, or neither,
+Workspace numbers appear on the bar by default. Clicking one takes you to that
+workspace, and clicking the one you are already on opens the naming panel,
+since there is nothing left to switch to. It holds a name field and, under it,
+a grid of icons. Fill in either, both, or neither,
 then press Enter to save. An empty name clears the name, the first cell of the
 grid (`×`) clears the icon, and clearing both hides the label. Escape closes
 without saving.
@@ -71,7 +72,8 @@ o.bind(hyper .. "R", "Workspace name", "omarchy-shell shell toggle jankeesvw.wor
 ## Workspace indicators
 
 Each button carries the workspace's icon where one is set and its number where
-none is, and clicking one focuses that workspace. It stands in for the
+none is. Clicking one focuses that workspace, and clicking the focused one
+opens the panel to name it. It stands in for the
 `omarchy.workspaces` widget rather than sitting beside it, so take that one out
 of the bar first.
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
     "allowMultiple": false,
     "defaultSection": "left",
     "defaults": {
-      "indicators": false,
+      "indicators": true,
       "numbers": false,
       "alwaysShown": 5
     },
@@ -29,7 +29,7 @@
         "key": "indicators",
         "type": "boolean",
         "label": "Draw the workspace indicators",
-        "defaultValue": false,
+        "defaultValue": true,
         "description": "A button per workspace, showing its icon where one is set and its number where none is. This stands in for the Workspaces widget rather than sitting beside it, so take that one out of the bar first."
       },
       {


### PR DESCRIPTION
On first install the workspace-name widget was invisible — no names, no icons, nothing to click, no way to discover the naming panel without reading the README and binding a key manually.

## Changes

- **Enable workspace number indicators by default** — workspace numbers (1–5) are always visible out of the box
- **Middle-click to open naming panel** — middle-click (or two-finger click on trackpad) any workspace button or the label to open the naming panel
- **Placeholder fallback** — when indicators are explicitly disabled and no name/icon is set, the current workspace number is shown as a clickable placeholder
- **Updated README** — documents the new workflow and how to disable indicators

## Before

- Empty bar slot on first install, nothing to click
- User must read README, discover `omarchy-shell shell toggle jankeesvw.workspace-name`, bind a key

## After

- Workspace numbers 1–5 shown by default
- Middle-click any number to open the naming panel and set a label